### PR TITLE
Feature ESBMS 103/configure db from dual database architecture

### DIFF
--- a/APIs/APIs.csproj
+++ b/APIs/APIs.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>a05476ef-4421-4954-bca9-c883c49e78c8</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/APIs/appsettings.json
+++ b/APIs/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "SqlServer": "Server=(localdb)\\MSSQLLocalDB;Database=EduBusDB;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "SqlServer_Staging": "Server=tcp:edubus-sql.database.windows.net,1433;Initial Catalog=Edubus;Persist Security Info=False;User ID=app_user;Password=StrongPass123!;MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30",
+    "SqlServer_Staging": "Server=tcp:edubus.database.windows.net,1433;Initial Catalog=EdubusDB;Persist Security Info=False;User ID=edubusdb_admin;Password={SqlPassword};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30",
     "MongoDB": "mongodb+srv://edubus_user:{MongoPassword}@cluster0.p6gr1mc.mongodb.net/EduBus?retryWrites=true&w=majority"
   },
   "MongoDB": {

--- a/APIs/appsettings.json
+++ b/APIs/appsettings.json
@@ -7,8 +7,9 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "SqlServer": "Server=localhost;Database=EduBus;Trusted_Connection=true;TrustServerCertificate=true;",
-    "MongoDB": "mongodb://localhost:27017"
+    "SqlServer": "Server=(localdb)\\MSSQLLocalDB;Database=EduBusDB;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "SqlServer_Staging": "Server=tcp:edubus-sql.database.windows.net,1433;Initial Catalog=Edubus;Persist Security Info=False;User ID=app_user;Password=StrongPass123!;MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30",
+    "MongoDB": "mongodb+srv://edubus_user:{MongoPassword}@cluster0.p6gr1mc.mongodb.net/EduBus?retryWrites=true&w=majority"
   },
   "MongoDB": {
     "DatabaseName": "EduBusDB"

--- a/Data/Contexts/SqlServer/EduBusSqlContext.cs
+++ b/Data/Contexts/SqlServer/EduBusSqlContext.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using System.Reflection;
+
+namespace Data.Contexts.SqlServer
+{
+    public class EduBusSqlContext : DbContext
+    {
+        private readonly IConfiguration _configuration;
+
+        public EduBusSqlContext(DbContextOptions<EduBusSqlContext> options, IConfiguration configuration)
+            : base(options)
+        {
+            _configuration = configuration;
+        }
+
+        // DbSet 
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // Apply Fluent API Configurations from current Assembly 
+            modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+
+        }
+    }
+}

--- a/Data/Data.csproj
+++ b/Data/Data.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="MongoDB.Driver" Version="3.4.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Contexts\SqlServer\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
feat: configure SQL Server & MongoDB staging with User Secrets based on dual database architecture
- Add staging/production configuration for MongoDB using User Secrets
- Integrate secrets loading into dual database architecture
- Remove hardcoded MongoDB passwords from appsettings.json
- Add SqlServer DbContext under Data/Contexts/SqlServer
- Update Program.cs to load MongoDB password dynamically from secrets manager
- Keep SQL Server configuration intact for all environments
- Update Khoi SQL Server connection string to use Staging on Azure via User Secrets
